### PR TITLE
fix exact trace computation for power series.

### DIFF
--- a/lib/layers/iresblock.py
+++ b/lib/layers/iresblock.py
@@ -154,7 +154,7 @@ class iResBlock(nn.Module):
                 jac_k = jac
                 for k in range(2, n_power_series + 1):
                     jac_k = torch.bmm(jac, jac_k)
-                    logdetgrad = logdetgrad + coeff_fn(k) * batch_trace(jac_k)
+                    logdetgrad = logdetgrad + (-1)**(k + 1) / k * coeff_fn(k) * batch_trace(jac_k)
 
             if self.training and self.n_power_series is None:
                 self.last_n_samples.copy_(torch.tensor(n_samples).to(self.last_n_samples))


### PR DESCRIPTION
Hi, the power series here for exact trace computation has a bug. You've used the Neumann gradient series instead of the correct one.